### PR TITLE
Allow for asdf installed version of golang to be used when building

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 # Dependencies
 
 - `bash`, `curl`, `tar`: generic POSIX utilities.
-- `go`: `brew install go`
+- `go`: `brew install go` OR `add `golang <version>` to your `.tool-versions` file
 - `SOME_ENV_VAR`: set this environment variable in your shell config to load the correct version of tool x.
 
 # Install
@@ -40,7 +40,7 @@ asdf list-all protoc-gen-go
 asdf install protoc-gen-go latest
 
 # Set a version globally (on your ~/.tool-versions file)
-asdf global protoc-gen-go latest
+asdf set -u protoc-gen-go latest
 
 # Now protoc-gen-go commands are available
 protoc-gen-go --version

--- a/bin/download
+++ b/bin/download
@@ -2,16 +2,12 @@
 
 set -euo pipefail
 
-current_script_path=${BASH_SOURCE[0]}
-# capture the go version currently in use by asdf, assuming you are installing from
-# the directory with the tool defined.  The following is the cleanest way I could
-# find to get the version of golang used
+# copy of PWD in case something changes it, PWD should be the directory where
+#   asdf install protoc-gen-go
+# is being called from
+WORKING_DIR=$PWD
 
-# first check if go is provided by asdf
-GOVERSION=
-if asdf list golang > /dev/null 2>&1 ; then
-  GOVERSION=$(basename $(asdf where golang))
-fi
+current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
 # shellcheck source=../lib/utils.bash
@@ -30,15 +26,15 @@ tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "
 
 # Build protoc-gen-go binary
 pushd "$ASDF_DOWNLOAD_PATH"/cmd/$TOOL_NAME >/dev/null 2>&1 || exit 1
-# if we found we were running within asdf, we'll add a .tool-version with the version of
-# go used via asdf for the current run path
-if test -n "$GOVERSION"; then
-  if ! test -f .tool-versions; then
-    echo "golang $GOVERSION" > .tool-versions
+# if we find a .tool-versions in the working directory (eg, the one asdf install is being called
+# from), we'll check for golang in that directory and if it's there, add that same version to
+# the checkout so that the build of protoc-gen-go below will use that version.
+if test -f $WORKING_DIR/.tool-versions ; then
+  if grep golang $WORKING_DIR/.tool-versions > /dev/null 2>&1 ; then
+    grep golang $WORKING_DIR/.tool-versions > .tool-versions
   fi
 fi
 go build || fail "Could not build $TOOL_NAME from $ASDF_DOWNLOAD_PATH"
-rm -f .tool-versions  # remove the temporary .tool-versions in case it matters
 popd >/dev/null 2>&1 || exit 1
 
 # Remove the tar.gz file since we don't need to keep it

--- a/bin/download
+++ b/bin/download
@@ -3,6 +3,15 @@
 set -euo pipefail
 
 current_script_path=${BASH_SOURCE[0]}
+# capture the go version currently in use by asdf, assuming you are installing from
+# the directory with the tool defined.  The following is the cleanest way I could
+# find to get the version of golang used
+
+# first check if go is provided by asdf
+GOVERSION=
+if asdf list golang > /dev/null 2>&1 ; then
+  GOVERSION=$(basename $(asdf where golang))
+fi
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
 # shellcheck source=../lib/utils.bash
@@ -21,7 +30,15 @@ tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "
 
 # Build protoc-gen-go binary
 pushd "$ASDF_DOWNLOAD_PATH"/cmd/$TOOL_NAME >/dev/null 2>&1 || exit 1
+# if we found we were running within asdf, we'll add a .tool-version with the version of
+# go used via asdf for the current run path
+if test -n "$GOVERSION"; then
+  if ! test -f .tool-versions; then
+    echo "golang $GOVERSION" > .tool-versions
+  fi
+fi
 go build || fail "Could not build $TOOL_NAME from $ASDF_DOWNLOAD_PATH"
+rm -f .tool-versions  # remove the temporary .tool-versions in case it matters
 popd >/dev/null 2>&1 || exit 1
 
 # Remove the tar.gz file since we don't need to keep it


### PR DESCRIPTION
I had the issue that with the `.tool-versions` of 
```
golang 1.24.0
protoc 29.3
protoc-gen-go 1.36.5
```
when I ran
```
$ asdf plugin add golang
$ asdf plugin add protoc
$ asdf plugin add protoc-gen-go
$ asdf install
```
It fails with
```
Platform 'darwin' supported!
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 72.5M  100 72.5M    0     0  69.0M      0  0:00:01  0:00:01 --:--:-- 69.0M
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    64  100    64    0     0    325      0 --:--:-- --:--:-- --:--:--   326
verifying checksum
~/.asdf/downloads/golang/1.24.0/archive.tar.gz: OK
checksum verified
Downloading https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protoc-29.3-osx-aarch_64.zip
* Downloading protoc-gen-go release 1.36.5...
No version is set for command go
Consider adding one of the following versions in your config file at ~/.asdf/downloads/protoc-gen-go/1.36.5/cmd/protoc-gen-go/.tool-versions
golang 1.24.0asdf-protoc-gen-go: Could not build protoc-gen-go from ~/.asdf/downloads/protoc-gen-go/1.36.5
failed to run download callback: exit status 1
```

I determined it was because the plugin was assuming that `go` was installed with `brew`.  I changed it to make the assumption that if the directory you are calling `asdf install` from has a `.tool-versions` file with `golang` in it, that you probably want to use that version.  And a `.tool-versions` file is added to the download to make it find the proper `go` version from asdf.

You can see this work by using
```
$ asdf plugin add golang
$ asdf plugin add protoc
$ asdf plugin add protoc-gen-go
$ asdf install https://github.com/djnym/asdf-protoc-gen-go.git
```
Which works
```
Platform 'darwin' supported!
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 72.5M  100 72.5M    0     0  6168k      0  0:00:12  0:00:12 --:--:-- 6594k
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    64  100    64    0     0    320      0 --:--:-- --:--:-- --:--:--   321
verifying checksum
~/.asdf/downloads/golang/1.24.0/archive.tar.gz: OK
checksum verified
Downloading https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protoc-29.3-osx-aarch_64.zip
* Downloading protoc-gen-go release 1.36.5...
protoc-gen-go 1.36.5 installation was successful!
```
I also tested by installing homebrew `go` with the following `.tools-version`
```
protoc 29.3
protoc-gen-go 1.36.5
```
Which also still works, so I feel this should be safe to merge.